### PR TITLE
Impement anti-correlation attestation penalties eip

### DIFF
--- a/beacon_node/store/src/partial_beacon_state.rs
+++ b/beacon_node/store/src/partial_beacon_state.rs
@@ -141,6 +141,8 @@ where
         List<PendingPartialWithdrawal, E::PendingPartialWithdrawalsLimit>,
     #[superstruct(only(Electra))]
     pub pending_consolidations: List<PendingConsolidation, E::PendingConsolidationsLimit>,
+    #[superstruct(only(Electra))]
+    pub net_excess_penalties: Vector<u64, E::NetExcessPenaltiesLimit>,
 }
 
 /// Implement the conversion function from BeaconState -> PartialBeaconState.
@@ -293,7 +295,8 @@ impl<E: EthSpec> PartialBeaconState<E> {
                     earliest_consolidation_epoch,
                     pending_balance_deposits,
                     pending_partial_withdrawals,
-                    pending_consolidations
+                    pending_consolidations,
+                    net_excess_penalties
                 ],
                 [historical_summaries]
             ),
@@ -566,7 +569,8 @@ impl<E: EthSpec> TryInto<BeaconState<E>> for PartialBeaconState<E> {
                     earliest_consolidation_epoch,
                     pending_balance_deposits,
                     pending_partial_withdrawals,
-                    pending_consolidations
+                    pending_consolidations,
+                    net_excess_penalties
                 ],
                 [historical_summaries]
             ),

--- a/consensus/state_processing/src/upgrade/electra.rs
+++ b/consensus/state_processing/src/upgrade/electra.rs
@@ -95,6 +95,8 @@ pub fn upgrade_to_electra<E: EthSpec>(
         exit_cache: mem::take(&mut pre.exit_cache),
         slashings_cache: mem::take(&mut pre.slashings_cache),
         epoch_cache: EpochCache::default(),
+        // TODO: Should initialize to the average of the previous epoch + some delta
+        net_excess_penalties: <_>::default(),
     });
     *post.exit_balance_to_consume_mut()? = post.get_activation_exit_churn_limit(spec)?;
     *post.consolidation_balance_to_consume_mut()? = post.get_consolidation_churn_limit(spec)?;

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -614,12 +614,9 @@ impl<E: EthSpec> BeaconState<E> {
         })
     }
 
+    #[allow(clippy::arithmetic_side_effects)]
     pub fn compute_penalty_factor(&self, flag_index: usize) -> Result<(u64, u64), Error> {
-        let mut net_excess_penalties = self
-            .net_excess_penalties()?
-            .get(flag_index)
-            .unwrap()
-            .clone();
+        let mut net_excess_penalties = *self.net_excess_penalties()?.get(flag_index).unwrap();
         let start_slot: u64 = self
             .slot()
             .epoch(E::slots_per_epoch())
@@ -631,9 +628,7 @@ impl<E: EthSpec> BeaconState<E> {
                 .progressive_balances_cache()
                 .get_inner()?
                 .current_epoch_cache;
-            let total_balance_per_slot = balance.total_flag_balance(0).unwrap()
-                + balance.total_flag_balance(1).unwrap()
-                + balance.total_flag_balance(2).unwrap();
+            let total_balance_per_slot = balance.total_flag_balance(flag_index).unwrap();
             let participating_balance = balance.per_slot_flag_balance(slot as usize, flag_index)?;
             penalty_factor = std::cmp::min(
                 ((total_balance_per_slot - participating_balance) * PENALTY_ADJUSTMENT_FACTOR)

--- a/consensus/types/src/beacon_state.rs
+++ b/consensus/types/src/beacon_state.rs
@@ -21,7 +21,6 @@ use swap_or_not_shuffle::compute_shuffled_index;
 use test_random_derive::TestRandom;
 use tree_hash::TreeHash;
 use tree_hash_derive::TreeHash;
-use typenum::U3;
 
 pub use self::committee_cache::{
     compute_committee_index_in_epoch, compute_committee_range_in_epoch, epoch_committee_count,
@@ -503,8 +502,9 @@ where
     #[test_random(default)]
     #[superstruct(only(Electra))]
     pub pending_consolidations: List<PendingConsolidation, E::PendingConsolidationsLimit>,
+    #[test_random(default)]
     #[superstruct(only(Electra))]
-    pub net_excess_penalties: Vector<u64, U3>,
+    pub net_excess_penalties: Vector<u64, E::NetExcessPenaltiesLimit>,
     // Caching (not in the spec)
     #[serde(skip_serializing, skip_deserializing)]
     #[ssz(skip_serializing, skip_deserializing)]
@@ -627,7 +627,7 @@ impl<E: EthSpec> BeaconState<E> {
             .into();
         let mut penalty_factor = 0;
         for slot in start_slot..self.slot().into() {
-            let balance = self
+            let balance = &self
                 .progressive_balances_cache()
                 .get_inner()?
                 .current_epoch_cache;

--- a/consensus/types/src/beacon_state/progressive_balances_cache.rs
+++ b/consensus/types/src/beacon_state/progressive_balances_cache.rs
@@ -19,7 +19,7 @@ pub struct ProgressiveBalancesCache {
 }
 
 #[derive(Debug, PartialEq, Arbitrary, Clone)]
-struct Inner {
+pub struct Inner {
     pub current_epoch: Epoch,
     pub previous_epoch_cache: EpochTotalBalances,
     pub current_epoch_cache: EpochTotalBalances,

--- a/consensus/types/src/consts.rs
+++ b/consensus/types/src/consts.rs
@@ -25,3 +25,7 @@ pub mod bellatrix {
 pub mod deneb {
     pub use crate::VERSIONED_HASH_VERSION_KZG;
 }
+pub mod electra {
+    pub const PENALTY_ADJUSTMENT_FACTOR: u64 = 4096;
+    pub const MAX_PENALTY_FACTOR: u64 = 4;
+}

--- a/consensus/types/src/eth_spec.rs
+++ b/consensus/types/src/eth_spec.rs
@@ -4,7 +4,7 @@ use safe_arith::SafeArith;
 use serde::{Deserialize, Serialize};
 use ssz_types::typenum::{
     bit::B0, UInt, U0, U1, U1024, U1048576, U1073741824, U1099511627776, U128, U131072, U134217728,
-    U16, U16777216, U2, U2048, U256, U262144, U32, U4, U4096, U512, U6, U625, U64, U65536, U8,
+    U16, U16777216, U2, U2048, U256, U262144, U3, U32, U4, U4096, U512, U6, U625, U64, U65536, U8,
     U8192,
 };
 use ssz_types::typenum::{U17, U9};
@@ -146,6 +146,7 @@ pub trait EthSpec:
     type MaxAttesterSlashingsElectra: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MaxAttestationsElectra: Unsigned + Clone + Sync + Send + Debug + PartialEq;
     type MaxWithdrawalRequestsPerPayload: Unsigned + Clone + Sync + Send + Debug + PartialEq;
+    type NetExcessPenaltiesLimit: Unsigned + Clone + Sync + Send + Debug + PartialEq;
 
     fn default_spec() -> ChainSpec;
 
@@ -389,6 +390,7 @@ impl EthSpec for MainnetEthSpec {
     type MaxAttesterSlashingsElectra = U1;
     type MaxAttestationsElectra = U8;
     type MaxWithdrawalRequestsPerPayload = U16;
+    type NetExcessPenaltiesLimit = U3;
 
     fn default_spec() -> ChainSpec {
         ChainSpec::mainnet()
@@ -422,6 +424,7 @@ impl EthSpec for MinimalEthSpec {
     type PendingConsolidationsLimit = U64;
     type MaxDepositReceiptsPerPayload = U4;
     type MaxWithdrawalRequestsPerPayload = U2;
+    type NetExcessPenaltiesLimit = U3;
 
     params_from_eth_spec!(MainnetEthSpec {
         JustificationBitsLength,
@@ -508,6 +511,7 @@ impl EthSpec for GnosisEthSpec {
     type MaxAttesterSlashingsElectra = U1;
     type MaxAttestationsElectra = U8;
     type MaxWithdrawalRequestsPerPayload = U16;
+    type NetExcessPenaltiesLimit = U3;
 
     fn default_spec() -> ChainSpec {
         ChainSpec::gnosis()


### PR DESCRIPTION
Implement anti correlation penalties

The decentralization of the validator set is one of the most important properties of Ethereum for credible neutrality and censorship resistance. By adjusting penalties to foster decentralization, diversification and fault-tolerance, diversified entities get lower penalties while entities with high correlations in their setup face more severe ones.